### PR TITLE
Pass all arguments except openapi-file to wiremock

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ idea {
 }
 
 group 'com.virgingates.tools'
-version '1.1'
+version '1.2'
 
 task createDockerfile(type: Dockerfile) {
     destFile = project.file('build/docker/Dockerfile')


### PR DESCRIPTION
I hope this project is still maintained.

We want to use this project (as a Docker image) for our tests. And we noticed that template rendering does not work at all. We tried to enable verbose mode, but it wasn't available as well.

After some digging I noticed that CLI arguments are not processed at all, they are just parsed, but not propagated to base class (`com.github.tomakehurst.wiremock.standalone.CommandLineOptions`).

Unfortunately, base class does not allow any customization of its option parser, particularly, it throws exception when unknown option is seen. So I created predicate that cuts `--openapi-file` option along with its argument from CLI args before passing it to base class' constructor.

Also fixed bug for help text not being rendered at all - now it's displayed and shows help text for `--openapi-file` option as well.